### PR TITLE
BUG fix the build string for 2.12 variants

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.12" %}
 {% set kernel_headers_version = "2.6.32" %}
-{% set build_number = "7" %}
+{% set build_number = "8" %}
 
 package:
   name: linux-sysroot
@@ -44,7 +44,7 @@ outputs:
       noarch: generic
       binary_relocation: False
       detect_binary_files_with_prefix: False
-      string: "{{ ctng_vendor }}_h{{ PKG_HASH }}_{{ build_number }}"
+      string: "{{ ctng_vendor }}_variant_h{{ PKG_HASH }}_{{ build_number }}"
 {% if ctng_vendor == "conda" %}
       track_features:
         - kernel-headers_{{ cross_target_platform }}_{{ version }}_{{ ctng_vendor }}
@@ -73,7 +73,7 @@ outputs:
       noarch: generic
       binary_relocation: False
       detect_binary_files_with_prefix: False
-      string: "{{ ctng_vendor }}_h{{ PKG_HASH }}_{{ build_number }}"
+      string: "{{ ctng_vendor }}_variant_h{{ PKG_HASH }}_{{ build_number }}"
 {% if ctng_vendor == "conda" %}
       track_features:
         - sysroot_{{ cross_target_platform }}_{{ version }}_{{ ctng_vendor }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
