### PR TITLE
remove libnsl

### DIFF
--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -26,6 +26,10 @@ if [[ "$target_machine" == "s390x" ]]; then
    ln -s $PWD/lib64/ld-* $PWD/lib64/ld64.so.1
 fi
 
+rm -f $PWD/lib64/libnsl*.so
+rm -f $PWD/usr/lib64/libnsl.a
+rm -f $PWD/usr/lib64/libnso.so
+
 ln -s $PWD/lib64 $PWD/lib
 
 cp "${SRC_DIR}"/binary-freebl/usr/lib64/libfreebl3.so ${PWD}/usr/lib64/.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Older glibc versions included `libnsl` but this was removed at some point. Some Conda-forge packages built with our older glibc will link to `libnsl`, causing them to break on more recent Linux distributions. This has been reported and discussed in several places, including

- https://github.com/conda-forge/python-feedstock/pull/507
- https://github.com/conda-forge/fiona-feedstock/issues/138
- https://github.com/conda-forge/cmake-feedstock/issues/69
- https://github.com/conda-forge/rasterio-feedstock/issues/220

We have now included `libnsl` in conda-forge, and built `python` and `xerces-c` against it. However, there may be other affected packages, or new packages may be added in the future that also run into this issue. This PR seeks to prevent that from happening by removing `libnsl` from this package, thereby preventing packages from automatically and mistakenly building against it.