### PR TITLE
add run_constrained to target glibc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.28" %}
 {% set kernel_headers_version = "4.18.0" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 {% set rpm_url = "https://repo.almalinux.org/vault/8.7/BaseOS/" ~ centos_machine ~ "/os/Packages" %}
 {% set appstream_rpm_url = "https://repo.almalinux.org/vault/8.7/AppStream/" ~ centos_machine ~ "/os/Packages" %}
 {% set powertools_rpm_url = "https://repo.almalinux.org/vault/8.7/PowerTools/" ~ centos_machine ~ "/os/Packages" %}
@@ -138,6 +138,8 @@ outputs:
       track_features:
         - sysroot_{{ cross_target_platform }}_{{ version }}
         - sysroot_{{ cross_target_platform }}_{{ version }}_feature_2
+      run_constrained:
+        - __glibc >={{ version }},<3.0.a0
       run_exports:
         strong:
           - __glibc >={{ version }},<3.0.a0


### PR DESCRIPTION
prevent installing sysroot 2.28 on a system with <=2.27

I'm not sure if this works right now, but it is related to #68. If we removed track_features today, sysroot 2.28 will be installed on all systems by default, regardless of glibc version, which wouldn't produce executables that can run on the system which created them (if indeed it could produce them at all).

Question: does it work/make sense to build and test against 2.28 on cos7? If not, then I think this should be added regardless of #68.