### PR TITLE
Set a cfg file for the sysroot for clang support

### DIFF
--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -56,3 +56,6 @@ rm -rf usr/lib/systemd
 rm -rf usr/share/doc
 
 popd
+
+mkdir -p ${PREFIX}/bin
+echo "--sysroot=${PREFIX}/${target_machine}-${ctng_vendor}-linux-gnu/sysroot" >> ${PREFIX}/bin/${target_machine}-${ctng_vendor}-linux-gnu.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_number = "5" %}
+{% set build_number = "6" %}
 
 {% set alma_version = "8.9" %}
 {% set glibc_version = "2.28" %}


### PR DESCRIPTION
Fixes https://github.com/conda-forge/clang-compiler-activation-feedstock/issues/145