### PR TITLE
Add alma10 sysroot

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,22 +11,22 @@ jobs:
       linux_64_centos_machineaarch64cross_target_platformlinux-aarch64target_machineaarch64:
         CONFIG: linux_64_centos_machineaarch64cross_target_platformlinux-aarch64target_machineaarch64
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
         SHORT_CONFIG: linux_64_centos_machineaarch64cross_targ_ha557b6b8
       linux_64_centos_machineppc64lecross_target_platformlinux-ppc64letarget_machinepowerpc64le:
         CONFIG: linux_64_centos_machineppc64lecross_target_platformlinux-ppc64letarget_machinepowerpc64le
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
         SHORT_CONFIG: linux_64_centos_machineppc64lecross_targ_hd1a56269
       linux_64_centos_machines390xcross_target_platformlinux-s390xtarget_machines390x:
         CONFIG: linux_64_centos_machines390xcross_target_platformlinux-s390xtarget_machines390x
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
         SHORT_CONFIG: linux_64_centos_machines390xcross_target_h54b16e43
       linux_64_centos_machinex86_64cross_target_platformlinux-64target_machinex86_64:
         CONFIG: linux_64_centos_machinex86_64cross_target_platformlinux-64target_machinex86_64
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
         SHORT_CONFIG: linux_64_centos_machinex86_64cross_targe_h77f47944
   timeoutInMinutes: 360
   variables: {}

--- a/.ci_support/linux_64_centos_machineaarch64cross_target_platformlinux-aarch64target_machineaarch64.yaml
+++ b/.ci_support/linux_64_centos_machineaarch64cross_target_platformlinux-aarch64target_machineaarch64.yaml
@@ -9,7 +9,7 @@ cross_target_platform:
 ctng_vendor:
 - conda
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 target_machine:
 - aarch64
 with_features:

--- a/.ci_support/linux_64_centos_machineaarch64cross_target_platformlinux-aarch64target_machineaarch64.yaml
+++ b/.ci_support/linux_64_centos_machineaarch64cross_target_platformlinux-aarch64target_machineaarch64.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 centos_machine:
 - aarch64
 channel_sources:

--- a/.ci_support/linux_64_centos_machineppc64lecross_target_platformlinux-ppc64letarget_machinepowerpc64le.yaml
+++ b/.ci_support/linux_64_centos_machineppc64lecross_target_platformlinux-ppc64letarget_machinepowerpc64le.yaml
@@ -9,7 +9,7 @@ cross_target_platform:
 ctng_vendor:
 - conda
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 target_machine:
 - powerpc64le
 with_features:

--- a/.ci_support/linux_64_centos_machineppc64lecross_target_platformlinux-ppc64letarget_machinepowerpc64le.yaml
+++ b/.ci_support/linux_64_centos_machineppc64lecross_target_platformlinux-ppc64letarget_machinepowerpc64le.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 centos_machine:
 - ppc64le
 channel_sources:

--- a/.ci_support/linux_64_centos_machines390xcross_target_platformlinux-s390xtarget_machines390x.yaml
+++ b/.ci_support/linux_64_centos_machines390xcross_target_platformlinux-s390xtarget_machines390x.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 centos_machine:
 - s390x
 channel_sources:

--- a/.ci_support/linux_64_centos_machines390xcross_target_platformlinux-s390xtarget_machines390x.yaml
+++ b/.ci_support/linux_64_centos_machines390xcross_target_platformlinux-s390xtarget_machines390x.yaml
@@ -9,7 +9,7 @@ cross_target_platform:
 ctng_vendor:
 - conda
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 target_machine:
 - s390x
 with_features:

--- a/.ci_support/linux_64_centos_machinex86_64cross_target_platformlinux-64target_machinex86_64.yaml
+++ b/.ci_support/linux_64_centos_machinex86_64cross_target_platformlinux-64target_machinex86_64.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 centos_machine:
 - x86_64
 channel_sources:

--- a/.ci_support/linux_64_centos_machinex86_64cross_target_platformlinux-64target_machinex86_64.yaml
+++ b/.ci_support/linux_64_centos_machinex86_64cross_target_platformlinux-64target_machinex86_64.yaml
@@ -9,7 +9,7 @@ cross_target_platform:
 ctng_vendor:
 - conda
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 target_machine:
 - x86_64
 with_features:

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -150,7 +150,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/linux-sysroot-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About linux-sysroot-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/linux-sysroot-feedstock/blob/main/LICENSE.txt)
 
-Home: https://repo.almalinux.org/vault/9.3
+Home: https://repo.almalinux.org/vault/10.0
 
 Package license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
 

--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 mkdir -p ${PREFIX}/${target_machine}-${ctng_vendor}-linux-gnu/sysroot
 pushd ${PREFIX}/${target_machine}-${ctng_vendor}-linux-gnu/sysroot > /dev/null 2>&1

--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -4,7 +4,6 @@ mkdir -p ${PREFIX}/${target_machine}-${ctng_vendor}-linux-gnu/sysroot
 pushd ${PREFIX}/${target_machine}-${ctng_vendor}-linux-gnu/sysroot > /dev/null 2>&1
 cp -Rf "${SRC_DIR}"/binary-glibc/* .
 mkdir -p usr/include
-cp -Rf "${SRC_DIR}"/binary-glibc-headers/include/* usr/include/ | true
 cp -Rf "${SRC_DIR}"/binary-glibc-devel/* usr/
 cp -Rf "${SRC_DIR}"/binary-glibc-static/* usr/
 cp -Rf "${SRC_DIR}"/binary-glibc-common/* usr/

--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -52,11 +52,6 @@ rm -f usr/include/rpcsvc/yp_prot.h
 rm -f usr/include/rpcsvc/ypupd.h
 rm -f usr/include/rpcsvc/yp.x
 
-if [[ "$target_machine" == "s390x" ]]; then
-   rm -rf $PWD/usr/lib64/ld64.so.1
-   ln -s $PWD/usr/lib64/ld-* $PWD/usr/lib64/ld64.so.1
-fi
-
 mkdir -p usr/share
 ln -sf ${PREFIX}/share/zoneinfo usr/share/zoneinfo
 

--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -17,11 +17,16 @@ fi
 rm -rf usr/lib
 ln -s $PWD/usr/lib64 $PWD/usr/lib
 
+if [ -d "lib64" ]; then
+    mv lib64/* usr/lib64/
+    rm -rf lib64
+fi
 if [ -d "lib" ]; then
-    mv lib/* lib64/
+    mv lib/* usr/lib64/
     rm -rf lib
 fi
-ln -s $PWD/lib64 $PWD/lib
+ln -s $PWD/usr/lib64 $PWD/lib64
+ln -s $PWD/usr/lib64 $PWD/lib
 
 ## Linking or building against libsnsl produces binaries that don't run on recent Linux distributions.
 ## Libraries and headers removed here to prevent this. See
@@ -37,8 +42,8 @@ rm -f usr/include/rpcsvc/ypupd.h
 rm -f usr/include/rpcsvc/yp.x
 
 if [[ "$target_machine" == "s390x" ]]; then
-   rm -rf $PWD/lib64/ld64.so.1
-   ln -s $PWD/lib64/ld-* $PWD/lib64/ld64.so.1
+   rm -rf $PWD/usr/lib64/ld64.so.1
+   ln -s $PWD/usr/lib64/ld-* $PWD/usr/lib64/ld64.so.1
 fi
 
 mkdir -p usr/share

--- a/recipe/build-sysroot.sh
+++ b/recipe/build-sysroot.sh
@@ -26,8 +26,18 @@ if [ -d "lib" ]; then
     mv lib/* usr/lib64/
     rm -rf lib
 fi
+if [ -d "sbin" ]; then
+    mv sbin/* usr/sbin/
+    rm -rf sbin
+fi
+if [ -d "bin" ]; then
+    mv bin/* usr/bin/
+    rm -rf bin
+fi
 ln -s $PWD/usr/lib64 $PWD/lib64
 ln -s $PWD/usr/lib64 $PWD/lib
+ln -s $PWD/usr/sbin $PWD/sbin
+ln -s $PWD/usr/bin $PWD/bin
 
 ## Linking or building against libsnsl produces binaries that don't run on recent Linux distributions.
 ## Libraries and headers removed here to prevent this. See

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,6 +17,10 @@ cross_target_platform:
 ctng_vendor:
   - conda
 
+# until it's the default in the pinning
+docker_image:
+  - quay.io/condaforge/linux-anvil-x86_64:alma10
+
 zip_keys:
   - - target_machine
     - cross_target_platform

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,15 +107,33 @@ outputs:
         - tzdata
     test:
       commands:
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/lib/libc.so.6
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/sbin/ldconfig
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/lib/crt1.o
+        # the files below are just a sample of the full content
+        {% for path_fragment in ["lib", "lib64", "usr/lib", "usr/lib64"] %}
+        # libraries & special objects
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/crt1.o
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/libc.a
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/libc.so.6
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/libdl.a
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/libm.a
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/libm.so.6
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/Scrt1.o
+        # ensure vendor templating worked correctly
+        - test -f $PREFIX/{{ target_machine }}-{{ ctng_vendor }}-linux-gnu/sysroot/{{ path_fragment }}/libc.so.6
+        {% endfor %}
+        {% for path_fragment in [".", "usr"] %}
+        # binaries
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/bin/ld.so
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/bin/ldd
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/sbin/ldconfig
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/{{ path_fragment }}/sbin/iconvconfig
+        {% endfor %}
+        # headers
         - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/limits.h
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs-64.h  # [cross_target_platform == "linux-64"]
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs.h  # [cross_target_platform != "linux-64"]
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs-64.h   # [cross_target_platform == "linux-64"]
+        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/include/gnu/stubs.h      # [cross_target_platform != "linux-64"]
+        # locale metadata
         - test -d $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/share/locale
-        - test -f $PREFIX/{{ target_machine }}-conda-linux-gnu/sysroot/usr/bin/ldd
-        - test -f $PREFIX/{{ target_machine }}-{{ ctng_vendor }}-linux-gnu/sysroot/lib/libc.so.6
+        # absence of removed libraries
         - find "${PREFIX}" \( -name 'libnsl*' -o -path '*/rpcsvc/yp*' \) | { ! grep . ; }
         - find "${PREFIX}" \( -name 'libcrypt*' -o -name 'crypt.*' \) | { ! grep . ; }
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set alma_version = "9.5" %}
-{% set glibc_version = "2.34" %}
-{% set kernel_headers_version = "5.14.0" %}
+{% set alma_version = "10.0" %}
+{% set glibc_version = "2.39" %}
+{% set kernel_headers_version = "6.12.0" %}
 {% set build_number = "2" %}
 
 {% set rpm_url = "https://repo.almalinux.org/almalinux/" ~ alma_version ~ "/BaseOS/" ~ centos_machine ~ "/os/Packages" %}
@@ -16,58 +16,53 @@ source:
   # in the recipe folder (only `alma_version` needs to be set therein)
   # START source
   - folder: binary-glibc
-    url: {{ rpm_url }}/glibc-2.34-125.el9_5.8.alma.1.{{ centos_machine }}.rpm
-    sha256: 1848b9ced2dfec6c206791b23a5a8a6356939c5ed0492fc91c86bf1d3a255c1d  # [cross_target_platform == "linux-64"]
-    sha256: 9d850f1736fdad076c46fbcae4355fbfdc63b1a13be112b01281a93029bd3b46  # [cross_target_platform == "linux-aarch64"]
-    sha256: 1a128d79d70f4790f78f84bcf4fdcfd22d7aea0b1fad678e2690db1909beea41  # [cross_target_platform == "linux-ppc64le"]
-    sha256: 9c685fdecfe7007163bd9759b75aca60f3fa27c33d16483e1b11b3b54c83157f  # [cross_target_platform == "linux-s390x"]
+    url: {{ rpm_url }}/glibc-2.39-46.el10_0.alma.1.{{ centos_machine }}.rpm
+    sha256: eaffc50805352fd935a3896a5bf84b8d60324bf58167520ae2ce8a5fe47b033a  # [cross_target_platform == "linux-64"]
+    sha256: 1d995ba5a2a7600b3db6641e11800d0c1dedeacd3ac96d4956dde6e4c45dba94  # [cross_target_platform == "linux-aarch64"]
+    sha256: b0ad96046475f4e7cfa6dac28b816f63f16ed73edd8c4c53017dabd403d3868c  # [cross_target_platform == "linux-ppc64le"]
+    sha256: d2d1cf8436d1b8283eb971ae11743e5dba8af9393a9dfac25d99436946aa1232  # [cross_target_platform == "linux-s390x"]
 
   - folder: binary-glibc-all-langpacks
-    url: {{ rpm_url }}/glibc-all-langpacks-2.34-125.el9_5.8.alma.1.{{ centos_machine }}.rpm
-    sha256: ce0681b433af2cf99b5da9e6f711087da4696a26dde4732b312ccf9a7c505536  # [cross_target_platform == "linux-64"]
-    sha256: c70ca549a0fbc2bc2825837e28b9de1bd1ca474df21f95de367c48cde804c87e  # [cross_target_platform == "linux-aarch64"]
-    sha256: 5717a4fdfa9a8d1117b3238b1b56204065250886cc7bd9db9ab1ae7da28b4c2f  # [cross_target_platform == "linux-ppc64le"]
-    sha256: 3a0b7b2c01cdd00b517ce4c19fd0f1b51ea42c66390f7a94dc0e57e58410fa1d  # [cross_target_platform == "linux-s390x"]
+    url: {{ rpm_url }}/glibc-all-langpacks-2.39-46.el10_0.alma.1.{{ centos_machine }}.rpm
+    sha256: 654c37662fc57f51e4526f39fe0c6fe79a59fa6b9e3078907a8ced2d442ee767  # [cross_target_platform == "linux-64"]
+    sha256: dd2894261cb8c2ce4077e5799d5c7d347248e0148b7462003258cbefb37eadd9  # [cross_target_platform == "linux-aarch64"]
+    sha256: fc835f165cb4a3117f06078002dfd7e4c56aefa611dc253d35ec63b285cc19ff  # [cross_target_platform == "linux-ppc64le"]
+    sha256: 5f49a5639172c1a272ecb8fa995be985ef8428646f3c2a861aaee4cc7877880a  # [cross_target_platform == "linux-s390x"]
 
   - folder: binary-glibc-common
-    url: {{ rpm_url }}/glibc-common-2.34-125.el9_5.8.alma.1.{{ centos_machine }}.rpm
-    sha256: 5b8582afb69c49880c2ceab98b392c22778e4670f348e8eb76697bd00c8f074e  # [cross_target_platform == "linux-64"]
-    sha256: 5d4a52d5bdf07b9799ff80626451db59ddc32a9eba4c0582a982e7ed11a86306  # [cross_target_platform == "linux-aarch64"]
-    sha256: 5ed8b096d3001291168e2688d39c1996ef00c1c68391f94c9abd86ef5f0ee4ef  # [cross_target_platform == "linux-ppc64le"]
-    sha256: dbbc3dd80cfcb8456612682ddd80024690edf37b57ceb049d0ea343c36366387  # [cross_target_platform == "linux-s390x"]
+    url: {{ rpm_url }}/glibc-common-2.39-46.el10_0.alma.1.{{ centos_machine }}.rpm
+    sha256: 0590078115b86a24c090a9211f79d5c3583a3a0e366928333e87fff206bcbfc6  # [cross_target_platform == "linux-64"]
+    sha256: 18e6181cf791a313b3858e019d1913de875419622d2bb69741b4ff1257e5435c  # [cross_target_platform == "linux-aarch64"]
+    sha256: aa0b6200d38fe8795696be546f72737a3cd1d9665c4f58aa371f93eab59f977b  # [cross_target_platform == "linux-ppc64le"]
+    sha256: 9a69a576a610a3331192dd5b230a800ca367cfa034ef68f9f5cf3d334175e892  # [cross_target_platform == "linux-s390x"]
 
   - folder: binary-glibc-devel
-    url: {{ appstream_rpm_url }}/glibc-devel-2.34-125.el9_5.8.alma.1.{{ centos_machine }}.rpm
-    sha256: bc0b102d7f9a6f730c75b8800e87a419b95c4ac8a20734e815bac45de7564e0c  # [cross_target_platform == "linux-64"]
-    sha256: 4b5bd0c424b1ae5b9272de14e9dff24756316ff894fa91ed946a68e88d1cf9a6  # [cross_target_platform == "linux-aarch64"]
-    sha256: f2a4303a2ec5d9d64b1de0401e740ed9f624c4e4bd47c6608792d11feb8ee485  # [cross_target_platform == "linux-ppc64le"]
-    sha256: b50fe1ffc31801e732afabad2f7a3630147306721d308a51dee4354ee907bda3  # [cross_target_platform == "linux-s390x"]
+    url: {{ appstream_rpm_url }}/glibc-devel-2.39-46.el10_0.alma.1.{{ centos_machine }}.rpm
+    sha256: 0e80f3d0c7c7caabd53a7ec8f0a987903ed2fdd3a1835d00ff5fcea88d84522c  # [cross_target_platform == "linux-64"]
+    sha256: 266ddc82c479dd0920a65cb9fcb309ae2a261d114c14114759d4cbcdf4bd056d  # [cross_target_platform == "linux-aarch64"]
+    sha256: 128b02570e112a62500f2024f0c9acc95622d308bf74829cfb117b289937aaf7  # [cross_target_platform == "linux-ppc64le"]
+    sha256: d497624b9272db332f57432ba4b2cb8e0fe708cb3653257fad8bd42059297cc6  # [cross_target_platform == "linux-s390x"]
 
   - folder: binary-glibc-gconv-extra
-    url: {{ rpm_url }}/glibc-gconv-extra-2.34-125.el9_5.8.alma.1.{{ centos_machine }}.rpm
-    sha256: b21cebfd6e96a3f8f8eb02b2317e69528649355657fe44a66b4b6dcc03fec638  # [cross_target_platform == "linux-64"]
-    sha256: c60c4aa567dc37cbc7247cb981996d04f09f4ff4cf553ad5cdc346d66da768cc  # [cross_target_platform == "linux-aarch64"]
-    sha256: 50808a6a71fd9a3d5b3db2604f825af8aa6cf0020dd8f1d0edca1b0bc77729f9  # [cross_target_platform == "linux-ppc64le"]
-    sha256: e7a9df0d9eb747b1dacf13636a4defb42123a0aa3d166adff9970736d1be073c  # [cross_target_platform == "linux-s390x"]
-
-  - folder: binary-glibc-headers                                              # [cross_target_platform in ("linux-64", "linux-s390x")]
-    url: {{ appstream_rpm_url }}/glibc-headers-2.34-125.el9_5.8.alma.1.{{ centos_machine }}.rpm  # [cross_target_platform in ("linux-64", "linux-s390x")]
-    sha256: 77fd486c81e4b841f52ac58fe0a713fb71fe3c688548e006b0752dd322616116  # [cross_target_platform == "linux-64"]
-    sha256: d2188c627c579568192af0c25583b1bd442c39182a08c94391ccab2f727ecdf4  # [cross_target_platform == "linux-s390x"]
+    url: {{ rpm_url }}/glibc-gconv-extra-2.39-46.el10_0.alma.1.{{ centos_machine }}.rpm
+    sha256: 7dd6f8ed9a0cd2120a7e55ccbd7cd1a49f027a38cae6b0e325e31b3c94a24435  # [cross_target_platform == "linux-64"]
+    sha256: 1bc539992ad1542d79606025bc63de2f1a548c62ca4842568c2bba66ba2c47ff  # [cross_target_platform == "linux-aarch64"]
+    sha256: 0e19730f8fb949f313cddabf1c7791060a7918a09ab961a98f6f4dbc891e89ac  # [cross_target_platform == "linux-ppc64le"]
+    sha256: b36eccde7afe826556cc430247ab332b2dec3ea6c7610a11cd8776b4d185e823  # [cross_target_platform == "linux-s390x"]
 
   - folder: binary-glibc-static
-    url: {{ crb_rpm_url }}/glibc-static-2.34-125.el9_5.8.alma.1.{{ centos_machine }}.rpm
-    sha256: 25a5b3547626c2d255a2f54333558b5d2e8054f305bbf8a2da85e11b187faec9  # [cross_target_platform == "linux-64"]
-    sha256: 8d196658cb4a590bd1d587ced02f2396d8db3ce47d12b9ed1c5aba0f4ab57fbb  # [cross_target_platform == "linux-aarch64"]
-    sha256: d4a8ada450f1629e58c1c3907f48f58c4fcd9587515fa7110f870e437f777be6  # [cross_target_platform == "linux-ppc64le"]
-    sha256: ea543fc40c4a1746fde6bbe4d48f8b969dd4c9bedf000327fe44297d68c9171a  # [cross_target_platform == "linux-s390x"]
+    url: {{ crb_rpm_url }}/glibc-static-2.39-46.el10_0.alma.1.{{ centos_machine }}.rpm
+    sha256: 7c7f2b722fd6271232226cebf099d48c0d2c2acfbc611bf5aa4f3c635f9d9774  # [cross_target_platform == "linux-64"]
+    sha256: 2aed5b932ba98cbe3a85a1b5ab25140e464b699d88d59c15e93fabadb1493879  # [cross_target_platform == "linux-aarch64"]
+    sha256: e5c2b3f174fe886a426d47a09a55a094a6cb1875181f92263c4bb70363c1ae40  # [cross_target_platform == "linux-ppc64le"]
+    sha256: 6186db49e5f938523c89fb099193cb72e99f93133afa7ea2b0fee66a5e7a0d3b  # [cross_target_platform == "linux-s390x"]
 
   - folder: binary-kernel-headers
-    url: {{ appstream_rpm_url }}/kernel-headers-5.14.0-503.40.1.el9_5.{{ centos_machine }}.rpm
-    sha256: df35eddfb6142d6f610c18580c8f95c2fcc7f2f6c14d3229d9bf2003a55042fc  # [cross_target_platform == "linux-64"]
-    sha256: c7c218002ed32f236a3b94c6f277f147c855d670e506a5b2a894a863e7f6f188  # [cross_target_platform == "linux-aarch64"]
-    sha256: befded36522113167ff4e8bd18e47b3134510e59deb2399c6ef4996b6b063e32  # [cross_target_platform == "linux-ppc64le"]
-    sha256: 568f164c6beccf5fdba181f7bdc05f9dc3f1b915c53171a59d1f03f29f2cfb27  # [cross_target_platform == "linux-s390x"]
+    url: {{ appstream_rpm_url }}/kernel-headers-6.12.0-55.32.1.el10_0.{{ centos_machine }}.rpm
+    sha256: d8b8bba28055296be5a9d5adf5b8a6ba1ae20c00336c7ed3eb7e7f971491a82a  # [cross_target_platform == "linux-64"]
+    sha256: ed517539e0f64697f86db581d6182effe4639c7c4a2f1f636f6c7d1ab211fa10  # [cross_target_platform == "linux-aarch64"]
+    sha256: e9523c8f8367030a0c2c235b1528ea2f304ee1557906488c6da5a49f48779ec2  # [cross_target_platform == "linux-ppc64le"]
+    sha256: b48ef88358bc6f382bfe41067ab39760ae8ccc3574d3a1fb2f848aa13a9c1795  # [cross_target_platform == "linux-s390x"]
   # END source
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,9 +67,6 @@ source:
 
 build:
   number: {{ build_number }}
-  noarch: generic
-  missing_dso_whitelist:
-    - '*'
 
 outputs:
   - name: kernel-headers_{{ cross_target_platform }}
@@ -92,6 +89,8 @@ outputs:
       noarch: generic
       binary_relocation: False
       detect_binary_files_with_prefix: False
+      missing_dso_whitelist:
+        - '*'
       track_features:
         - sysroot_{{ cross_target_platform }}_{{ glibc_version }}               # [with_features]
         - sysroot_{{ cross_target_platform }}_{{ glibc_version }}_feature_2     # [with_features]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,9 +3,9 @@
 {% set kernel_headers_version = "5.14.0" %}
 {% set build_number = "2" %}
 
-{% set rpm_url = "https://repo.almalinux.org/vault/" ~ alma_version ~ "/BaseOS/" ~ centos_machine ~ "/os/Packages" %}
-{% set appstream_rpm_url = "https://repo.almalinux.org/vault/" ~ alma_version ~ "/AppStream/" ~ centos_machine ~ "/os/Packages" %}
-{% set crb_rpm_url = "https://repo.almalinux.org/vault/" ~ alma_version ~ "/CRB/" ~ centos_machine ~ "/os/Packages" %}
+{% set rpm_url = "https://repo.almalinux.org/almalinux/" ~ alma_version ~ "/BaseOS/" ~ centos_machine ~ "/os/Packages" %}
+{% set appstream_rpm_url = "https://repo.almalinux.org/almalinux/" ~ alma_version ~ "/AppStream/" ~ centos_machine ~ "/os/Packages" %}
+{% set crb_rpm_url = "https://repo.almalinux.org/almalinux/" ~ alma_version ~ "/CRB/" ~ centos_machine ~ "/os/Packages" %}
 
 package:
   name: linux-sysroot

--- a/recipe/update.py
+++ b/recipe/update.py
@@ -29,7 +29,7 @@ config = load(cbc_content, Loader=BaseLoader)
 rpm_arches = config["centos_machine"]
 conda_arches = config["cross_target_platform"]
 
-alma_version = "9.5"
+alma_version = "10.0"
 
 url_template = (
     f"https://repo.almalinux.org/vault/{alma_version}"
@@ -63,13 +63,12 @@ logging.info(f"Fetching content of {appstream_frontpage}")
 appstream_pkgs_html = requests.get(appstream_frontpage).content.decode("utf-8")
 
 # glibc artefacts have two build numbers plus the alma version, e.g.
-#   2.34-125.el9_5.8.alma.1.x86_64.rpm
-#   ↑    ↑     ↑   ↑      ↑
+#   2.39-46.el10_0.alma.1.x86_64.rpm
+#   ↑    ↑     ↑        ↑
 #   └glibc_ver └alma_version
-#        └build1   └build2└build3
+#        └build1        └build2
 glibc_build1 = 0
 glibc_build2 = 0
-glibc_build3 = 0
 glibc_version = 0
 kernel_headers_build = Version("0.0.0")
 kernel_headers_version = 0
@@ -78,7 +77,7 @@ for line in (baseos_pkgs_html + appstream_pkgs_html).splitlines():
     line = line.strip()
     if not line.startswith("<a href=\""):
         continue
-    line = line[len('<a href="./'):]
+    line = line[len('<a href="'):]
     url = line[:line.index("\">")]
 
     if el_ver not in url:
@@ -88,15 +87,10 @@ for line in (baseos_pkgs_html + appstream_pkgs_html).splitlines():
         continue
 
     name, version, build = url.rsplit("-", 2)
-    # glibc-2.34-125.el9_5.8.alma.1.x86_64.rpm
+    # glibc-2.39-46.el10_0.alma.1.x86_64.rpm
     if name == "glibc":
         glibc_build1 = max(glibc_build1, int(build.split(".")[0]))
-        glibc_build2 = max(glibc_build2, int(build.split(".")[2]))
-        try:
-            # don't use max; build3 is not necessarily increasing from oldest to newest
-            glibc_build3 = int(build.split(".")[4])
-        except:
-            pass
+        glibc_build2 = max(glibc_build2, int(build.split(".")[3]))
         glibc_version = version
 
     # kernel-headers-4.18.0-513.24.1.el8_9.x86_64.rpm
@@ -109,7 +103,7 @@ if glibc_version == 0:
 if kernel_headers_version == 0:
     raise ValueError("could not determine kernel-headers version!")
 
-glibc_string = f"{glibc_version}-{glibc_build1}.{el_ver}.{glibc_build2}.alma.{glibc_build3}"
+glibc_string = f"{glibc_version}-{glibc_build1}.{el_ver}.alma.{glibc_build2}"
 kernel_headers_string = f"{kernel_headers_version}-{kernel_headers_build}.{el_ver}"
 
 logging.info(f"Determined {glibc_string=}")
@@ -124,7 +118,6 @@ name2string = {
     "glibc-common": glibc_string,
     "glibc-devel": glibc_string,
     "glibc-gconv-extra": glibc_string,
-    "glibc-headers": glibc_string,
     "glibc-static": glibc_string,
     "kernel-headers": kernel_headers_string,
 }

--- a/recipe/update.py
+++ b/recipe/update.py
@@ -32,7 +32,8 @@ conda_arches = config["cross_target_platform"]
 alma_version = "10.0"
 
 url_template = (
-    f"https://repo.almalinux.org/vault/{alma_version}"
+    # switch back `almalinux` -> `vault` as soon as those packages get populated
+    f"https://repo.almalinux.org/almalinux/{alma_version}"
     # second part intententionally not filled yet
     "/{subfolder}/{arch}/os/Packages"
 )


### PR DESCRIPTION
https://repo.almalinux.org/vault/10.0/BaseOS/ exists but is still empty. It should be filled once alma 10.1 is out, which might happen in November. In the meantime, use packages from https://repo.almalinux.org/almalinux. Later, we should simply be able to revert 0de3517704e26ea237c592cd8b58eedadb0e5acd.

Fixes #91 